### PR TITLE
Fix for cron export multiple stores magento bug

### DIFF
--- a/code/Model/Feed.php
+++ b/code/Model/Feed.php
@@ -39,6 +39,10 @@ class Clerk_Clerk_Model_Feed extends Mage_Core_Helper_Abstract
 		$appEmulation = Mage::getSingleton('core/app_emulation');
 		$initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($storeId);
 
+			// http://magento.stackexchange.com/questions/25808
+			Mage::getResourceModel('catalog/product_collection')
+				->setStore($storeId);
+
 			$collection = Mage::getModel('catalog/product')->getCollection()->addStoreFilter($storeId);
 
 			$filters = Mage::helper('clerk')->getProductCollectionFilters();


### PR DESCRIPTION
When you have *multiple* stores using the Clerk feed export a cached store_id in Magento core code doesn't get reset. This patch implements a workaround for [that bug](http://magento.stackexchange.com/questions/25808). This only occurs when using the cron export. This doesn't happen when you use the admin export.
