### PR TITLE
Complete PR #29 and remove Powerstep block constructor

### DIFF
--- a/code/Block/Powerstep.php
+++ b/code/Block/Powerstep.php
@@ -1,15 +1,34 @@
 <?php
 
-// app/code/local/Envato/Recentproducts/Block/Recentproducts.php
 class Clerk_Clerk_Block_Powerstep extends Mage_Core_Block_Template
 {
-    protected function _construct()
-    {
-        $this->product = Mage::getModel('catalog/product')->load(
-            Mage::getSingleton('checkout/session')->getLastAddedProductId());
-        $this->quote = Mage::getSingleton('checkout/session')->getQuote();
-        $this->templates = Mage::helper('clerk')->getSetting('clerk/powerstep/templates');
-        $this->templates = array_map('trim', explode(',', $this->templates));
-        $this->firePopUp = Mage::getSingleton('core/session')->getFirePowerPopup(true);
+    protected function getProduct() {
+        if (is_null($this->product)) {
+            $this->product = Mage::getModel('catalog/product')->load(
+                Mage::getSingleton('checkout/session')->getLastAddedProductId());
+        }
+        return $this->product;
+    }
+
+    protected function getQuote() {
+        if (is_null($this->quote)) {
+            $this->quote = Mage::getSingleton('checkout/session')->getQuote();
+        }
+        return $this->quote;
+    }
+
+    protected function getTemplates() {
+        if (is_null($this->templates)) {
+            $this->templates = Mage::helper('clerk')->getSetting('clerk/powerstep/templates');
+            $this->templates = array_map('trim', explode(',', $this->templates));
+        }
+        return $this->templates;
+    }
+
+    protected function getFirePopUp() {
+        if (is_null($this->firePopUp)) {
+            $this->firePopUp = Mage::getSingleton('core/session')->getFirePowerPopup(true);
+        }
+        return $this->firePopUp;
     }
 }

--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -5,7 +5,7 @@ class Clerk_Clerk_Model_Observer
     /**
      * The function is run by the observer when a new product is added to the cart.
      */
-    public function itemAddedToCard($observer)
+    public function itemAddedToCart($observer)
     {
         if (!Mage::helper('clerk')->getSetting('clerk/powerstep/active')) {
             return;

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -59,7 +59,7 @@
           <clerk_checkout_cart_add_product_complete>
             <type>singleton</type>
             <class>Clerk_Clerk_Model_Observer</class>
-            <method>itemAddedToCard</method>
+            <method>itemAddedToCart</method>
           </clerk_checkout_cart_add_product_complete>
         </observers>
       </checkout_cart_add_product_complete>

--- a/design/layout/clerk.xml
+++ b/design/layout/clerk.xml
@@ -12,7 +12,7 @@
       </action>
     </reference>
     <reference name="before_body_end">
-			<block type="core/template" name="clerk_livesearch_script" after="-">
+      <block type="core/template" name="clerk_livesearch_script" after="-">
         <action method="setTemplate" ifconfig="clerk/livesearch/active">
           <template>clerk/livesearch.phtml</template>
         </action>
@@ -41,7 +41,7 @@
     </reference>
   </checkout_onepage_success>
 
-	<checkout_cart_clerk>
+  <checkout_cart_clerk>
     <reference name="root">
       <action method="setTemplate" ifconfig="clerk/general/active">
         <template>page/1column.phtml</template>

--- a/design/template/powerpage.phtml
+++ b/design/template/powerpage.phtml
@@ -4,18 +4,18 @@
         <div class="col6 left padding10">
             <div class="col12 ">
                 <div class="alert alert-success">
-                    <?php echo $this->__('%s was successfully added to your shopping cart.', $this->product->getName()); ?>
+                    <?php echo $this->__('%s was successfully added to your shopping cart.', $this->getProduct()->getName()); ?>
                 </div>
             </div>
 
             <div class="col12">
                 <div class="col4 left clerk-product-image">
-                    <img src="<?php echo $this->helper('catalog/image')->init($this->product, 'small_image')->resize(100); ?>"
-                         alt="<?php echo $this->stripTags($this->getImageLabel($this->product, 'small_image'), null, true) ?>" />
+                    <img src="<?php echo $this->helper('catalog/image')->init($this->getProduct(), 'small_image')->resize(100); ?>"
+                         alt="<?php echo $this->stripTags($this->getImageLabel($this->getProduct(), 'small_image'), null, true) ?>" />
                 </div>
                 <div class="col8 left">
-                    <span class="clerk-name"><?php echo $this->product->getName() ?></span>
-                    <?php echo $this->getLayout()->createBlock('catalog/product_price')->getPriceHtml($this->product); ?>
+                    <span class="clerk-name"><?php echo $this->getProduct()->getName() ?></span>
+                    <?php echo $this->getLayout()->createBlock('catalog/product_price')->getPriceHtml($this->getProduct()); ?>
                 </div>
             </div>
             <div class="clerk-clearer"></div>
@@ -32,13 +32,13 @@
                 <table class="table">
                     <tr>
                         <td class="clerk-text padding10-top" >
-                          <?php echo $this->__('You have %s products in your shopping cart', count($this->quote->getAllVisibleItems())); ?>
+                          <?php echo $this->__('You have %s products in your shopping cart', count($this->getQuote()->getAllVisibleItems())); ?>
                        </td>
                         <td></td>
                     </tr>
                     <tr class="clerk-total">
                         <td class="clerk-text"><?php echo Mage::helper('clerk')->__('Total'); ?></td>
-                        <td class="clerk-price"><?php echo Mage::helper('core')->currency($this->quote->getGrandTotal(), true, false); ?></td>
+                        <td class="clerk-price"><?php echo Mage::helper('core')->currency($this->getQuote()->getGrandTotal(), true, false); ?></td>
                     </tr>
                 </table>
             </div>
@@ -60,8 +60,8 @@
     <div class="clerk-clearer"></div>
 
     <div class="clerk-results">
-        <?php foreach ($this->templates as $template) : ?>
-            <span class="clerk" data-template="@<?php echo $template ?>" data-products="[<?php echo $this->product->getId(); ?>]"></span>
+        <?php foreach ($this->getTemplates() as $template) : ?>
+            <span class="clerk" data-template="@<?php echo $template ?>" data-products="[<?php echo $this->getProduct()->getId(); ?>]"></span>
         <?php endforeach; ?>
     </div>
     <div class="clerk-clearer"></div>

--- a/design/template/powerpopup.phtml
+++ b/design/template/powerpopup.phtml
@@ -1,4 +1,6 @@
-<?php if ($this->firePopUp) : ?>
+<?php
+
+if ($this->getFirePopUp()) : ?>
 
 <span id="clerk-power-popup" style="display:none">
 
@@ -6,18 +8,18 @@
         <div class="col6 left padding10">
             <div class="col12 ">
                 <div class="alert alert-success">
-                    <?php echo $this->__('%s was successfully added to your shopping cart.', $this->product->getName()); ?>
+                    <?php echo $this->__('%s was successfully added to your shopping cart.', $this->getProduct()->getName()); ?>
                 </div>
             </div>
 
             <div class="col12">
                 <div class="col4 left clerk-product-image">
-                    <img src="<?php echo $this->helper('catalog/image')->init($this->product, 'small_image')->resize(100); ?>"
-                         alt="<?php echo $this->stripTags($this->getImageLabel($this->product, 'small_image'), null, true) ?>" />
+                    <img src="<?php echo $this->helper('catalog/image')->init($this->getProduct(), 'small_image')->resize(100); ?>"
+                         alt="<?php echo $this->stripTags($this->getImageLabel($this->getProduct(), 'small_image'), null, true) ?>" />
                 </div>
                 <div class="col8 left">
-                    <span class="clerk-name"><?php echo $this->product->getName() ?></span>
-                    <?php echo $this->getLayout()->createBlock('catalog/product_price')->getPriceHtml($this->product); ?>
+                    <span class="clerk-name"><?php echo $this->getProduct()->getName() ?></span>
+                    <?php echo $this->getLayout()->createBlock('catalog/product_price')->getPriceHtml($this->getProduct()); ?>
                 </div>
             </div>
             <div class="clerk-clearer"></div>
@@ -34,13 +36,13 @@
                 <table class="table">
                     <tr>
                         <td class="clerk-text padding10-top" >
-                          <?php echo $this->__('You have %s products in your shopping cart', count($this->quote->getAllVisibleItems())); ?>
+                          <?php echo $this->__('You have %s products in your shopping cart', count($this->getQuote()->getAllVisibleItems())); ?>
                        </td>
                         <td></td>
                     </tr>
                     <tr class="clerk-total">
                         <td class="clerk-text"><?php echo Mage::helper('clerk')->__('Total'); ?></td>
-                        <td class="clerk-price"><?php echo Mage::helper('core')->currency($this->quote->getGrandTotal(), true, false); ?></td>
+                        <td class="clerk-price"><?php echo Mage::helper('core')->currency($this->getQuote()->getGrandTotal(), true, false); ?></td>
                     </tr>
                 </table>
             </div>
@@ -64,8 +66,8 @@
 
 
     <div class="clerk-results">
-        <?php foreach ($this->templates as $template) : ?>
-            <span class="clerk" data-after-render="clerk_fire_power_popup" data-template="@<?php echo $template ?>" data-products="[<?php echo $this->product->getId(); ?>]"></span>
+        <?php foreach ($this->getTemplates() as $template) : ?>
+            <span class="clerk" data-after-render="clerk_fire_power_popup" data-template="@<?php echo $template ?>" data-products="[<?php echo $this->getProduct()->getId(); ?>]"></span>
         <?php endforeach; ?>
     </div>
 </span>

--- a/design/template/powerpopup.phtml
+++ b/design/template/powerpopup.phtml
@@ -12,7 +12,7 @@
 
             <div class="col12">
                 <div class="col4 left clerk-product-image">
-                    <img src="<?php echo $this->helper('catalog/image')->init($this->product, 'image')->resize(100); ?>"
+                    <img src="<?php echo $this->helper('catalog/image')->init($this->product, 'small_image')->resize(100); ?>"
                          alt="<?php echo $this->stripTags($this->getImageLabel($this->product, 'small_image'), null, true) ?>" />
                 </div>
                 <div class="col8 left">


### PR DESCRIPTION
Hi, these patches do three things plus some whitespace fixes:

1. rename the function itemAddedToCard -> itemAddedToCart
2. copy #29 into the powerpopup template as well as the powerpage one.
3. Breaks the Powerstep block constructor up because:
```
If the powerstep is enabled, the powerpopup block & template is loaded on
every page. If an item has been added to the cart, the block constructor
will load the product on every subsequent page load.

This patch moves the constructor into get functions and updates the
templates.
```