### PR TITLE
OrganicInternet_SimpleConfigurableProducts Compatibility

### DIFF
--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -71,4 +71,33 @@ class Clerk_Clerk_Model_Observer
     {
         Mage::getModel('clerk/communicator')->syncAll();
     }
+
+    /**
+     * Allow the SCP ext configurable product id (cpid) to override
+     * the product id sent to clerk. By default, Magento will store
+     * two rows in sale_flat_order_item table; one for the simple +
+     * one for the associated configurable. SCP doesn't work like this
+     * so determine the configurable id from the product options instead.
+     *
+     * @param Varien_Event_Observer $observer
+     */
+    public function formatScpOrderItem(Varien_Event_Observer $observer)
+    {
+        if (!Mage::helper('core')->isModuleEnabled('OrganicInternet_SimpleConfigurableProducts')) {
+            return;
+        }
+
+        /** @var array $output */
+        $output = $observer->getEvent()->getOutput();
+
+        /** @var Mage_Sales_Model_Order_Item $_item */
+        $_item = $observer->getEvent()->getItem();
+
+        /** @var array $buyRequest */
+        $buyRequest = $_item->getProductOptionByCode('info_buyRequest');
+
+        if ($buyRequest && isset($buyRequest['cpid'])) {
+            $output['id'] = (int) $buyRequest['cpid'];
+        }
+    }
 }

--- a/code/Model/Orderpage.php
+++ b/code/Model/Orderpage.php
@@ -35,7 +35,7 @@ class Clerk_Clerk_Model_Orderpage
             if ($_item->getParentItem()) {
                 continue;
             }
-            $item = array();
+            $item = new Varien_Object();
             $total_before_discount = $_item->getRowTotalInclTax();
             $total_with_discount =
                 (float) ($total_before_discount - $_item->getDiscountAmount());
@@ -44,17 +44,30 @@ class Clerk_Clerk_Model_Orderpage
             $item['id'] = (int) $_item->getProductId();
             $item['quantity'] = (int) $_item->getQtyOrdered();
             $item['price'] = $actual_product_price;
-            $items[] = $item;
+
+            Mage::dispatchEvent('clerkio_orderpage_format_item', array(
+                    'output' => $item,
+                    'item' => $_item,
+                )
+            );
+
+            $items[] = $item->getData();
         }
 
-        $data = array();
+        $data = new Varien_Object();
         $data['id'] = $order->getIncrementId();
         $data['customer'] = (int) $order->getCustomerId();
         $data['products'] = $items;
         $data['email'] = (string) $order->getCustomerEmail();
         $data['time'] = (int) strtotime($order->getCreatedAt());
 
-        return $data;
+        Mage::dispatchEvent('clerkio_orderpage_format_order', array(
+                'output' => $data,
+                'order' => $order,
+            )
+        );
+
+        return $data->getData();
     }
 
     private function fetch()

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -60,6 +60,14 @@
                     </clerk_catalog_product_attribute_update_after>
                 </observers>
             </catalog_product_attribute_update_after>
+            <clerkio_orderpage_format_item>
+                <observers>
+                    <clerk>
+                        <class>clerk/observer</class>
+                        <method>formatScpOrderItem</method>
+                    </clerk>
+                </observers>
+            </clerkio_orderpage_format_item>
         </events>
     </global>
     <frontend>


### PR DESCRIPTION
adapt order sync to work with OrganicInternet_SimpleConfigurableProducts extension by inferring the parent configurable from the cpid product option rather than the parent_item_id in sales_flat_order_item