### PR TITLE
CMS pages - getCollection must be first parameter

### DIFF
--- a/code/controllers/ApiController.php
+++ b/code/controllers/ApiController.php
@@ -118,9 +118,9 @@ class Clerk_Clerk_ApiController extends Mage_Core_Controller_Front_Action
 
         if (Mage::getStoreConfigFlag('clerk/general/sync_cms_pages')) {
             $pages = Mage::getModel('cms/page')
+                ->getCollection()
                 ->addFieldToFilter('is_active', '1')
-                ->addStoreFilter(Mage::app()->getStore()->getId())
-                ->getCollection();
+                ->addStoreFilter(Mage::app()->getStore()->getId());
 
             foreach ($pages as $page) {
                 $data = array(


### PR DESCRIPTION
CMS pages - getCollection must be first parameter
Reverse of change in latest release

This issue crashes data sync