### PR TITLE
IMPORTANT: fixes pagination of category API

### DIFF
--- a/code/controllers/ApiController.php
+++ b/code/controllers/ApiController.php
@@ -126,7 +126,7 @@ class Clerk_Clerk_ApiController extends Mage_Core_Controller_Front_Action
             ->addAttributeToFilter('path', array('like' => "1/{$rootCategoryId}/%"))
             ->setOrder('entity_id', Varien_Db_Select::SQL_ASC)
             ->setPageSize($limit)
-            ->setCurPage($page + 1);
+            ->setCurPage($page);
 
         $items = [];
 
@@ -144,9 +144,9 @@ class Clerk_Clerk_ApiController extends Mage_Core_Controller_Front_Action
             $items[] = $data;
         }
 
-        $this->getResponse()->setHeader('Total-Page-Count', $categories->getLastPageNumber() - 1);
+        $this->getResponse()->setHeader('Total-Page-Count', $categories->getLastPageNumber());
 
-        if ($page > $categories->getLastPageNumber() - 1) {
+        if ($page > $categories->getLastPageNumber()) {
             $this->getResponse()->setBody(json_encode([]));
         } else {
             $this->getResponse()->setBody(json_encode($items));
@@ -219,7 +219,7 @@ class Clerk_Clerk_ApiController extends Mage_Core_Controller_Front_Action
     private function setStore()
     {
         $storeid = $this->getRequest()->getParam('store');
-        
+
         if (isset($storeid) && is_numeric($storeid)) {
             try {
                 Mage::app()->getStore((int) $storeid);


### PR DESCRIPTION
Fixes the following unwanted behaviors of category API:

* It returns categories of page 2 when `page=1`
* The "Total-Page-Count" header is wrong (0 for 1 page, 1 for 2 pages, etc...)
* If there are less then `limit` categories it returns an empty array (for
example if there are 15 categories it returns an emptu array with `page=1` and
`limit=100`)