### PR TITLE
Clerk API Single product ID fix

### DIFF
--- a/code/controllers/ApiController.php
+++ b/code/controllers/ApiController.php
@@ -83,7 +83,7 @@ class Clerk_Clerk_ApiController extends Mage_Core_Controller_Front_Action
         if ($id) {
             $id = $this->getIntParam('id');
             if (Mage::helper('clerk')->isProductIdValid($id)) {
-                $data = Mage::getModel('clerk/product')->load($id)->getInfo();
+                $response = Mage::getModel('clerk/product')->load($id)->getInfo();
             } else {
                 $response = [
                     'error' => [


### PR DESCRIPTION
When taking a single product within the clerk api (&id=123), it would always return NULL. It used the $data variable, which was not used anywhere else, instead, $response should have been used.