### PR TITLE
Fixes error Illegal string offset 'label' on system config page

### DIFF
--- a/code/Block/Adminhtml/System/Config/Form/AttributeLabels.php
+++ b/code/Block/Adminhtml/System/Config/Form/AttributeLabels.php
@@ -17,7 +17,7 @@ class Clerk_Clerk_Block_Adminhtml_System_Config_Form_AttributeLabels extends Mag
 
         $values = json_decode($element->getValue(), true);
 
-        foreach (explode(',', $attributes) as $attribute) {
+        foreach ($attributes as $attribute) {
             $value = isset($values[$attribute]) ? $values[$attribute] : $attribute;
 
             $html .= '<tr>';
@@ -37,12 +37,19 @@ class Clerk_Clerk_Block_Adminhtml_System_Config_Form_AttributeLabels extends Mag
     /**
      * Get configured facet attributes
      *
-     * @return mixed
+     * @return array
      * @throws Mage_Core_Model_Store_Exception
      */
     protected function getConfiguredAttributes()
     {
-        return Mage::getStoreConfig(Clerk_Clerk_Model_Config::XML_PATH_FACETED_SEARCH_ATTRIBUTES, $this->getStore());
+        $rawConfiguredAttributes = Mage::getStoreConfig(
+            Clerk_Clerk_Model_Config::XML_PATH_FACETED_SEARCH_ATTRIBUTES,
+            $this->getStore()
+        );
+        if (empty($rawConfiguredAttributes)) {
+            return [];
+        }
+        return array_map('trim', explode(',', $rawConfiguredAttributes));
     }
 
     /**


### PR DESCRIPTION
On the Clerk's system configuration page, in the Magento backend,
if the system config `clerk/faceted_search/attributes` is empty
you'll get the following error:

```
Warning: Illegal string offset 'label'  in ../Block/Adminhtml/System/Config/Form/AttributeLabels.php on line 25
```

This is fixed now.