### PR TITLE
Fix remove product

### DIFF
--- a/code/Model/Communicator.php
+++ b/code/Model/Communicator.php
@@ -81,7 +81,7 @@ class Clerk_Clerk_Model_Communicator extends Mage_Core_Helper_Abstract
 
                 if ($enabled) {
                     $data = [];
-                    $data['products'] = [$productId];
+                    $data['products'] = json_encode([$productId]);
                     $data['key'] = $this->getPublicKey($storeId);
                     $data['private_key'] = $this->getPrivateKey($storeId);
 


### PR DESCRIPTION
The current code of the `\Clerk_Clerk_Model_Communicator::removeProduct` will produce the following request params:

```json
{
  "private_key": "*** redacted ***",
  "products[0]": 52964,
  "key": "*** redacted ***"
}
```

Which will result in a `Missing argument: products` ParsingError on Clerk.io.

This PR fix this.

